### PR TITLE
Add `reversed` attribute to posts list

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,4 +1,4 @@
-<ol class="postlist" style="counter-reset: start-from {{ postslist.length + 1 }}">
+<ol reversed class="postlist" style="counter-reset: start-from {{ postslist.length + 1 }}">
 {% for post in postslist | reverse %}
 	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
 		<a href="{{ post.url | url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>


### PR DESCRIPTION
Without CSS, the last post will be number 1. In browsers other than IE and Edge (where it's currently under consideration), the `reversed` attribute will match the effect of the CSS counter. I like putting the attribute first so it's clear that it's a particular kind of "ordered list: reversed."