### PR TITLE
Add archives page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,6 +12,11 @@ module.exports = function(eleventyConfig) {
     return DateTime.fromJSDate(dateObj).toFormat("dd LLL yyyy");
   });
 
+  // Get the first `n` elements of a collection.
+  eleventyConfig.addFilter("head", (array, n) => {
+    return array.slice(0, n);
+  });
+
   // only content in the `posts/` directory
   eleventyConfig.addCollection("posts", function(collection) {
     return collection.getAllSorted().filter(function(item) {

--- a/archive.njk
+++ b/archive.njk
@@ -1,0 +1,12 @@
+---
+layout: layouts/home.njk
+tags:
+  - nav
+navtitle: Archive
+permalink: posts/index.html
+---
+
+<h1>Blog post archive</h1>
+
+{% set postslist = collections.posts %}
+{% include "postslist.njk" %}

--- a/index.njk
+++ b/index.njk
@@ -4,5 +4,10 @@ tags:
   - nav
 navtitle: Home
 ---
-{% set postslist = collections.posts %}
+
+<h1>Latest 2 blog posts</h1>
+
+{% set postslist = collections.posts | head(2) %}
 {% include "postslist.njk" %}
+
+<p>More posts can be found in <a href="/posts/">the blog archive</a>.</p>


### PR DESCRIPTION
Blogs commonly only display the latest `n` blog posts on the home page, while showing the full list on a separate archive page. This change implements that.

(Don't feel obligated to accept this; I just created the PR as I needed this myself and it seems like a common thing to do.)