### PR TITLE
Update tags.njk to use subdir paths for the "all tags" page

### DIFF
--- a/tags.njk
+++ b/tags.njk
@@ -18,4 +18,4 @@ permalink: /tags/{{ tag }}/
 {% set postslist = collections[ tag ] %}
 {% include "postslist.njk" %}
 
-<p>See <a href="/tags/">all tags</a>.</p>
+<p>See <a href="{{ '/tags/' | url }}">all tags</a>.</p>


### PR DESCRIPTION
Used the same URL pattern for relative paths that I have seen elsewhere.
