### PR TITLE
Use tagList with full filter instead of just excluding posts from main post list

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -4,7 +4,7 @@
     <a href="{{ post.url | url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
     <time class="postlist-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate }}</time>
     {% for tag in post.data.tags %}
-      {%- if tag != "posts" -%}
+      {%- if collections.tagList.indexOf(tag) != -1 -%}
       {% set tagUrl %}/tags/{{ tag }}/{% endset %}
       <a href="{{ tagUrl | url }}" class="tag">{{ tag }}</a>
       {%- endif -%}


### PR DESCRIPTION
See it in action at this page: https://cassey-til.glitch.me/ 
See code for cassey-til.glitch.me: https://glitch.com/edit/#!/cassey-til

Makes use of the file in _11ty/getTagList.js and the collection it is used to create to filter out tags from display on the front page. 

Before: 
![image](https://user-images.githubusercontent.com/4480480/58897882-ff800900-86be-11e9-9ca9-5c80a7224a9a.png)


After: 
![image](https://user-images.githubusercontent.com/4480480/58897844-eaa37580-86be-11e9-89ae-61791638b417.png)
