### PR TITLE
Run browsersync in ghost mode by default

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,7 +61,12 @@ module.exports = function(eleventyConfig) {
           res.write(content_404);
           res.end();
         });
-      }
+      },
+    ghostMode: {
+      clicks: false,
+      forms: false,
+      scroll: false,
+    },
     }
   });
 


### PR DESCRIPTION
The average user probably does not want every reader's scroll position synced to every other reader.

Found this after sharing a blog post on cassey-til.glitch.me, and the people I shared it with reported that their scroll position kept changing without them taking any action. Very disruptive reading experience!

https://www.browsersync.io/docs/options#option-ghostMode

@zachleat this might even be worth including in the default eleventy config, it was hard to discover and a pretty big departure from how I expect blogs to work.