### PR TITLE
Adds support for Stackbit Uniform Themes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -33,6 +33,10 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("img");
   eleventyConfig.addPassthroughCopy("css");
 
+  if (fs.existsSync("admin")) {
+    eleventyConfig.addPassthroughCopy("admin");
+  }
+
   /* Markdown Plugins */
   let markdownIt = require("markdown-it");
   let markdownItAnchor = require("markdown-it-anchor");

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ A starter repository showing how to build a blog with the [Eleventy](https://git
 
 * [Netlify](https://eleventy-base-blog.netlify.com/)
 * [Get your own Eleventy web site on Netlify](https://app.netlify.com/start/deploy?repository=https://github.com/11ty/eleventy-base-blog)—seriously, just click OK a few times and it’s live—Netlify is amazing.
+
+  [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/11ty/eleventy-base-blog)
 * [GitHub Pages](https://11ty.github.io/eleventy-base-blog/)
+* [Get your own Eleventy web site on Stackbit](https://app.stackbit.com/create?theme=https://github.com/stackbithq/eleventy-base-blog)—this is powered by a single config file, [stackbit.yaml](https://docs.stackbit.com/uniform/stackbit-yaml/), which defines a [Uniform theme model](https://docs.stackbit.com/uniform/) and enables integration with CMS like Contentful, DatoCMS, Forestry, NetlifyCMS, etc.
+
+  [![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/stackbithq/eleventy-base-blog)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A starter repository showing how to build a blog with the [Eleventy](https://git
 
   [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/11ty/eleventy-base-blog)
 * [GitHub Pages](https://11ty.github.io/eleventy-base-blog/)
-* [Get your own Eleventy web site on Stackbit](https://app.stackbit.com/create?theme=https://github.com/stackbithq/eleventy-base-blog)—this is powered by a single config file, [stackbit.yaml](https://docs.stackbit.com/uniform/stackbit-yaml/), which defines a [Uniform theme model](https://docs.stackbit.com/uniform/) and enables integration with CMS like Contentful, DatoCMS, Forestry, NetlifyCMS, etc.
+* [Get your own Eleventy web site on Stackbit](https://app.stackbit.com/create?theme=https://github.com/11ty/eleventy-base-blog)—this is powered by a single config file, [stackbit.yaml](https://docs.stackbit.com/uniform/stackbit-yaml/), which defines a [Uniform theme model](https://docs.stackbit.com/uniform/) and enables integration with CMS like Contentful, DatoCMS, Forestry, NetlifyCMS, etc.
 
-  [![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/stackbithq/eleventy-base-blog)
+  [![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/11ty/eleventy-base-blog)
 
 ## Getting Started
 

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -6,7 +6,6 @@
     "subtitle": "I am writing about my experiences as a naval navel-gazer.",
     "filename": "feed.xml",
     "path": "/feed/feed.xml",
-    "url": "https://myurl.com/feed/feed.xml",
     "id": "https://myurl.com/"
   },
   "author": {

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -14,7 +14,7 @@
       <h1 class="home"><a href="{{ '/' | url }}">{{ metadata.title }}</a></h1>
       <ul class="nav">
         {%- for nav in collections.nav | reverse -%}
-        <li class="nav-item{% if nav.url == page.url %} nav-item-active{% endif %}"><a href="{{ nav.url | url }}">{{ nav.data.navtitle }}</a></li>
+        <li class="nav-item{% if nav.url == page.url %} nav-item-active{% endif %}"><a href="{{ nav.url | url }}">{{ nav.data.navtitle or nav.data.title }}</a></li>
         {%- endfor -%}
       </ul>
     </header>

--- a/feed/feed.njk
+++ b/feed/feed.njk
@@ -6,7 +6,8 @@ eleventyExcludeFromCollections: true
 <feed xmlns="http://www.w3.org/2005/Atom">
 	<title>{{ metadata.title }}</title>
 	<subtitle>{{ metadata.feed.subtitle }}</subtitle>
-	<link href="{{ metadata.feed.url }}" rel="self"/>
+	{% set absoluteUrl %}{{ metadata.feed.path | url | absoluteUrl(metadata.url) }}{% endset %}
+	<link href="{{ absoluteUrl }}" rel="self"/>
 	<link href="{{ metadata.url }}"/>
 	<updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
 	<id>{{ metadata.feed.id }}</id>

--- a/posts/fourthpost.md
+++ b/posts/fourthpost.md
@@ -2,7 +2,8 @@
 title: This is my fourth post.
 description: This is a post on My Blog about touchpoints and circling wagons.
 date: 2018-09-30
-tags: second-tag
+tags:
+  - second-tag
 layout: layouts/post.njk
 ---
 Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster collaborative thinking to further the overall value proposition. Organically grow the holistic world view of disruptive innovation via workplace diversity and empowerment.

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,133 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+buildCommand: "npm install && npm run build"
+publishDir: _site
+staticDir: ""
+uploadDir: img
+dataDir: _data
+pagesDir: ""
+pageLayoutKey: layout
+models:
+  metadata:
+    type: data
+    label: Site metadata
+    file: metadata.json
+    fields:
+      - name: title
+        label: Title
+        type: string
+      - name: url
+        label: Absolute site URL
+        type: string
+      - name: description
+        label: Description
+        type: string
+      - name: feed
+        label: RSS feed details
+        type: object
+        fields:
+          - name: subtitle
+            label: Sub-title
+            type: string
+          - name: filename
+            label: File name
+            type: string
+            hidden: true
+          - name: path
+            label: Path
+            type: string
+            hidden: true
+          - name: id
+            label: Feed ID
+            type: string
+      - name: author
+        label: Author
+        type: object
+        fields:
+          - name: name
+            label: Name
+            type: string
+          - name: email
+            label: Email
+            type: string
+  page:
+    type: page
+    label: Page
+    layout: layouts/post.njk
+    match: "**/*.md"
+    exclude: "{404.md,README.md,posts/**}"
+    fields:
+      - name: title
+        label: Title
+        type: string
+        required: true
+      - name: description
+        label: Description
+        type: string
+      - name: navtitle
+        label: Navigation item title
+        type: string
+      - name: tags
+        label: Tags
+        description: "Add the 'nav' tag to add to the top level site navigation"
+        type: list
+      - name: templateClass
+        label: Body class
+        type: string
+        const: tmpl-post
+        hidden: true
+      - name: permalink
+        label: Permalink
+        description: URL of the page
+        type: string
+      - name: eleventyExcludeFromCollections
+        label: Exclude content from collections
+        type: boolean
+        default: false
+  post:
+    type: page
+    label: Post
+    layout: layouts/post.njk
+    folder: posts
+    match: "**/*.md"
+    fields:
+      - name: title
+        label: Title
+        type: string
+        required: true
+      - name: date
+        label: Date
+        type: date
+        required: true
+      - name: description
+        label: Description
+        type: string
+      - name: tags
+        label: Tags
+        type: list
+      - name: permalink
+        label: Permalink
+        description: URL of the page
+        type: string
+      - name: eleventyExcludeFromCollections
+        label: Exclude content from collections
+        type: boolean
+        default: false
+  not_found:
+    type: page
+    label: 404 page
+    singleInstance: true
+    file: 404.md
+    layout: layouts/home.njk
+    fields:
+      - name: permalink
+        label: Permalink
+        description: URL of the page
+        type: string
+        const: 404.html
+        hidden: true
+      - name: eleventyExcludeFromCollections
+        label: Exclude content from collections
+        type: boolean
+        default: true
+        hidden: true


### PR DESCRIPTION
### Turn themes into CMS-powered websites

[Stackbit](https://www.stackbit.com/) provisions your theme's content model with a growing selection of headless CMS and pulls the content for you in the format your static site generator expects it. This is powered by a single config file, [stackbit.yaml](https://docs.stackbit.com/uniform/stackbit-yaml/), which defines a [Uniform theme model](https://docs.stackbit.com/uniform/) and enables integration with CMS like Contentful, DatoCMS, Forestry, NetlifyCMS, etc.

@zachleat This PR currently relies #38 and #37 being merged before hand as they reduce a little bit of friction when it comes to editing the site in the users chosen CMS, but they aren't essential and I can refactor them out if needed. 

https://github.com/11ty/eleventy-base-blog/commit/01aeec93e6bc0900ac1c43c5eb4eb0a62b621e2f may be the only change that you aren't happy with, because it removes some of the in-built flexibility of tags because the CMS rely on a consistent data type. So please let me know your thoughts