### PR TITLE
Remove npx from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "5.0.0",
   "description": "A starter repository for a blog web site using the Eleventy static site generator.",
   "scripts": {
-    "build": "npx eleventy",
-    "watch": "npx eleventy --watch",
-    "debug": "DEBUG=* npx eleventy"
+    "build": "eleventy",
+    "watch": "eleventy --watch",
+    "debug": "DEBUG=* eleventy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running npm scripts with `npm run build` or `yarn build`, the installed bins are already available in the path. That means there is no need for `npx` prefix.