### PR TITLE
Add ZEIT Now one-click deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A starter repository showing how to build a blog with the [Eleventy](https://git
 
 * [Netlify](https://eleventy-base-blog.netlify.com/)
 * [Get your own Eleventy web site on Netlify](https://app.netlify.com/start/deploy?repository=https://github.com/11ty/eleventy-base-blog)—seriously, just click OK a few times and it’s live—Netlify is amazing.
+* [Get your own Eleventy web site on ZEIT Now](https://zeit.co/new/project?template=11ty/eleventy-base-blog)—seriously, just click OK a few times and it’s live—ZEIT Now is amazing.
 * [GitHub Pages](https://11ty.github.io/eleventy-base-blog/)
 
 ## Getting Started


### PR DESCRIPTION
I wasn't sure what formatting to use here so I followed the Netlify example above which is very similar to ZEIT Now's [one-click deployment](https://zeit.co/new/project?template=11ty/eleventy-base-blog).