### PR TITLE
Remove tags from tab order and link them separately

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -6,7 +6,7 @@
     {% for tag in post.data.tags %}
       {%- if tag != "posts" -%}
       {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-      <a href="{{ tagUrl | url }}" class="tag">{{ tag }}</a>
+      <a href="{{ tagUrl | url }}" class="tag" tabindex="-1">{{ tag }}</a>
       {%- endif -%}
     {% endfor %}
   </li>

--- a/archive.njk
+++ b/archive.njk
@@ -10,3 +10,5 @@ eleventyNavigation:
 
 {% set postslist = collections.posts %}
 {% include "postslist.njk" %}
+
+<p>See <a href="{{ '/tags/' | url }}">all tags</a>.</p>

--- a/index.njk
+++ b/index.njk
@@ -11,3 +11,5 @@ eleventyNavigation:
 {% include "postslist.njk" %}
 
 <p>More posts can be found in <a href="{{ '/posts/' | url }}">the archive</a>.</p>
+
+<p>See <a href="{{ '/tags/' | url }}">all tags</a>.</p>


### PR DESCRIPTION
Browsing `/` and `/archive` without a mouse or with a screen reader is pretty annoying since for each item listed via `postslist.njk` its corresponding tag is being read.

In this PR I propose to remove tags in such cases from the tab order and instead to link them separately.