### PR TITLE
Avoid name clash with `tag` in HTML syntax highlighting

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -6,7 +6,7 @@
     {% for tag in post.data.tags %}
       {%- if collections.tagList.indexOf(tag) != -1 -%}
       {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-      <a href="{{ tagUrl | url }}" class="tag">{{ tag }}</a>
+      <a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a>
       {%- endif -%}
     {% endfor %}
   </li>

--- a/css/index.css
+++ b/css/index.css
@@ -181,7 +181,7 @@ pre {
 
 
 /* Tags */
-.tag {
+.post-tag {
   display: inline-block;
   vertical-align: text-top;
   text-transform: uppercase;
@@ -193,8 +193,8 @@ pre {
   border-radius: 0.25em; /* 3px /12 */
   text-decoration: none;
 }
-a[href].tag,
-a[href].tag:visited {
+a[href].post-tag,
+a[href].post-tag:visited {
   color: #fff;
 }
 

--- a/tags-list.njk
+++ b/tags-list.njk
@@ -6,5 +6,5 @@ layout: layouts/home.njk
 
 {% for tag in collections.tagList %}
   {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-  <a href="{{ tagUrl | url }}" class="tag">{{ tag }}</a>
+  <a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a>
 {% endfor %}


### PR DESCRIPTION
Solves [this](https://github.com/11ty/eleventy-plugin-syntaxhighlight/issues/25)