### PR TITLE
Use eleventyComputed instead of renderData

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ renderData.title or title or metadata.title }}</title>
-    <meta name="Description" content="{{ renderData.description or description or metadata.description }}">
+    <title>{{ title or metadata.title }}</title>
+    <meta name="description" content="{{ description or metadata.description }}">
     <link rel="stylesheet" href="{{ '/css/index.css' | url }}">
     <link rel="stylesheet" href="{{ '/css/prism-base16-monokai.dark.css' | url }}">
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">

--- a/tags.njk
+++ b/tags.njk
@@ -11,7 +11,7 @@ pagination:
     - tagList
   addAllPagesToCollections: true
 layout: layouts/home.njk
-renderData:
+eleventyComputed:
   title: Tagged “{{ tag }}”
 permalink: /tags/{{ tag }}/
 ---


### PR DESCRIPTION
This removes `renderData` usage in favor of `eleventyComputed`.

The [11ty docs](https://www.11ty.dev/docs/advanced-order/) say that `renderData` is undocumented and deprecated. I also found an [old issue](https://github.com/11ty/eleventy-base-blog/issues/15#issuecomment-589798575) with some discussion supporting this change.

Things should behave exactly the same. :)