### PR TITLE
Reverse order of posts in feed

### DIFF
--- a/feed/feed.njk
+++ b/feed/feed.njk
@@ -15,7 +15,7 @@ eleventyExcludeFromCollections: true
 		<name>{{ metadata.author.name }}</name>
 		<email>{{ metadata.author.email }}</email>
 	</author>
-	{%- for post in collections.posts %}
+	{%- for post in collections.posts | reverse %}
 	{% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
 	<entry>
 		<title>{{ post.data.title }}</title>


### PR DESCRIPTION
* Allows feed readers to make sure they get the latest post, even of parsing is limited.

Closes #68 