### PR TITLE
Add Docker local dev via feature/docker

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,23 +77,6 @@ module.exports = function(eleventyConfig) {
   });
   eleventyConfig.setLibrary("md", markdownLibrary);
 
-  // Browsersync Overrides
-  eleventyConfig.setBrowserSyncConfig({
-    callbacks: {
-      ready: function(err, browserSync) {
-        const content_404 = fs.readFileSync('_site/404.html');
-
-        browserSync.addMiddleware("*", (req, res) => {
-          // Provides the 404 content without redirect.
-          res.write(content_404);
-          res.end();
-        });
-      },
-    },
-    ui: false,
-    ghostMode: false
-  });
-
   return {
     templateFormats: [
       "md",

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,6 +77,22 @@ module.exports = function(eleventyConfig) {
   });
   eleventyConfig.setLibrary("md", markdownLibrary);
 
+  // Browsersync Overrides
+  eleventyConfig.setBrowserSyncConfig({
+    callbacks: {
+      ready: function(err, browserSync) {
+        const content_404 = fs.readFileSync('_site/404.html');
+
+        browserSync.addMiddleware("*", (req, res) => {
+          // Provides the 404 content without redirect.
+          res.write(content_404);
+          res.end();
+        });
+      },
+    },
+    ghostMode: false
+  });
+
   return {
     templateFormats: [
       "md",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+ARG TAG=12-alpine
+FROM node:$TAG
+
+WORKDIR /app
+
+CMD ["build"]
+
+ENTRYPOINT ["npm", "run"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+TAG?=12-alpine
+
+docker:
+	docker build \
+		. \
+		-t nystudio107/node:${TAG} \
+		--build-arg TAG=${TAG} \
+		--no-cache
+npm:
+	docker container run \
+		--name 11ty \
+		--rm \
+		-t \
+		-p 8080:8080 \
+		-p 3001:3001 \
+		-v `pwd`:/app \
+		nystudio107/node:${TAG} \
+		$(filter-out $@,$(MAKECMDGOALS))
+%:
+	@:
+# ref: https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Or in debug mode:
 make npm debug
 ```
 
+More detail on this Docker setup can be found in the [Running Node.js in Docker for local development](https://nystudio107.com/blog/run-your-node-js-apps-buildchains-via-docker) article.
+
 ### Implementation Notes
 
 * `about/index.md` shows how to add a content page.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,38 @@ Or in debug mode:
 DEBUG=* npx eleventy
 ```
 
+### Run Eleventy via Docker
+
+This project comes with an optional [Docker](https://www.docker.com/) config ready to go.
+
+Just have [Docker installed](https://docs.docker.com/get-docker/) and then from the project directory, run in your Terminal:
+
+```
+make docker
+make npm install
+```
+
+Then you can use any of the scripts in your `package.json` to run the project via Docker container:
+
+```
+make npm build
+```
+
+Or build and host locally for local development
+```
+make npm serve
+```
+
+Or build automatically when a template changes:
+```
+make npm watch
+```
+
+Or in debug mode:
+```
+make npm debug
+```
+
 ### Implementation Notes
 
 * `about/index.md` shows how to add a content page.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.2",
   "description": "A starter repository for a blog web site using the Eleventy static site generator.",
   "scripts": {
+    "install": "npm install",
     "build": "eleventy",
     "watch": "eleventy --watch",
     "serve": "eleventy --serve",


### PR DESCRIPTION
Adds a quick and easy way to run 11ty out of the box via Node.js on Docker, detailed in the [Running Node.js in Docker for local development](https://nystudio107.com/blog/run-your-node-js-apps-buildchains-via-docker) article.

This "shrink wraps" the devops needed to run 11ty into a Docker container, and allows people to run 11ty builds/serves without having Node.js installed locally (or having to care about the version of Node.js that they have).

Might be outside of what you want to do, which is fine... but I'd be happy to add this to your other starters if you like.

Edit: looks like the build failed because it ran out of memory:

```
FATAL ERROR: NewSpace::Rebalance Allocation failed - process out of memory
```