### PR TITLE
Add missing colon to `json.njk`

### DIFF
--- a/feed/json.njk
+++ b/feed/json.njk
@@ -6,7 +6,7 @@ eleventyExcludeFromCollections: true
 {
   "version": "https://jsonfeed.org/version/1.1",
   "title": "{{ metadata.title }}",
-  "language" "{{ metadata.language }}",
+  "language": "{{ metadata.language }}",
   "home_page_url": "{{ metadata.url }}",
   "feed_url": "{{ metadata.jsonfeed.url }}",
   "description": "{{ metadata.description }}",


### PR DESCRIPTION
Fixes malformed JSON feed output