### PR TITLE
Replace tag with eleventyNavigation in navigation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ DEBUG=* npx eleventy
 
 * `about/index.md` shows how to add a content page.
 * `posts/` has the blog posts but really they can live in any directory. They need only the `post` tag to be added to this collection.
-* Add the `nav` tag to add a template to the top level site navigation. For example, this is in use on `index.njk` and `about/index.md`.
+* Use the `eleventyNavigation` key in your front matter to add a template to the top level site navigation. For example, this is in use on `index.njk` and `about/index.md`.
 * Content can be any template format (blog posts needn’t be markdown, for example). Configure your supported templates in `.eleventy.js` -> `templateFormats`.
 	* Because `css` and `png` are listed in `templateFormats` but are not supported template types, any files with these extensions will be copied without modification to the output (while keeping the same directory structure).
 * The blog post feed template is in `feed/feed.njk`. This is also a good example of using a global data files in that it uses `_data/metadata.json`.


### PR DESCRIPTION
Top level navigation has been updated in https://github.com/11ty/eleventy-base-blog/commit/c9018fa45bfde4f684f7de5b70673f47912672de to use `eleventyNavigation` instead of the `nav` tag. We have to update the readme file to also account for this change.