### PR TITLE
Fix usage of `level` in the options object for `markdown-it-anchor`

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,9 +73,9 @@ module.exports = function(eleventyConfig) {
     permalink: markdownItAnchor.permalink.ariaHidden({
       placement: "after",
       class: "direct-link",
-      symbol: "#",
-      level: [1,2,3,4],
+      symbol: "#"
     }),
+    level: [1,2,3,4],
     slugify: eleventyConfig.getFilter("slug")
   });
   eleventyConfig.setLibrary("md", markdownLibrary);


### PR DESCRIPTION
I noticed that the `level` option is misplaced. [It should be passed with the `opts` object for `markdown-it-anchor`.](https://github.com/valeriangalliat/markdown-it-anchor#usage)

Since this option is misplaced, its default value (1) is used. Meaning, anchors are applied to headings of all levels. According to the code only headings with levels `[1,2,3,4]` should get anchors. Please let me know if this is the correct behavior.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/8535926/132216531-fdd324f0-f212-4651-9347-89558974a50a.png) | ![after](https://user-images.githubusercontent.com/8535926/132216585-3ef92eab-a7e2-48cc-8cfc-3ce28bbd39a5.png)