### PR TITLE
Turn off debug in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "_site"
-  command = "DEBUG=* eleventy"
+  command = "eleventy"


### PR DESCRIPTION
First of all thank your for the awesome project!

I've been using this template for [my project](https://github.com/defront/defront.ru) for more than 2 years. Recently the build time became unacceptable, because I have almost 1000 articles. As it turned out the problem was in the debug messages, there was too much of them so they affected I/O performance. I think that by default debug should be turned off.