### PR TITLE
Update Color in a[href].post-tag:hover

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -213,6 +213,7 @@ a[href].post-tag:visited {
 a[href].post-tag:hover,
 a[href].post-tag:focus {
   background-color: var(--color-gray-20);
+  color: #15202b;
 }
 .postlist-item > .post-tag {
   align-self: center;


### PR DESCRIPTION
When hovering over the buttons, the background color is white, which means you cannot read the text (also white). My fix uses the background color from the main page.

After
![before](https://user-images.githubusercontent.com/38789408/185057046-d4e46595-0103-4cf3-8c2f-9fd9d661291b.png)

Before
![after](https://user-images.githubusercontent.com/38789408/185057073-5b4d61e0-266e-489f-ac79-16cd6bf3f0d6.png)
