### PR TITLE
Add GH actions for deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - run: npm install
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./_site
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
While reading the `README` I found that the [GitHub Pages](https://11ty.github.io/eleventy-base-blog/) link is outdated.

I'm proposing this action to keep the [gh-pages branch](https://github.com/11ty/eleventy-base-blog/tree/gh-pages) up to date

A demo for this can be seen with my fork at https://agustinramirodiaz.github.io/eleventy-base-blog/

This might require some configuration in the repo's `settings->actions->Workflow permissions`:
- give `GITHUB_TOKEN` read and write permissions 

Credits to [the inspiration](https://www.rockyourcode.com/how-to-deploy-eleventy-to-github-pages-with-github-actions/)