### PR TITLE
Add GitLab Pages and Cloudflare Pages to inline 404 help

### DIFF
--- a/content/404.md
+++ b/content/404.md
@@ -11,9 +11,10 @@ Go <a href="/">home</a>.
 
 Read more: https://www.11ty.dev/docs/quicktips/not-found/
 
-This will work for both GitHub pages and Netlify:
+This will work for GitHub pages, GitLab Pages, Netlify, and Cloudflare Pages:
 
 * https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/
+* https://docs.gitlab.com/ee/user/project/pages/introduction.html#custom-error-codes-pages
 * https://www.netlify.com/docs/redirects/#custom-404
-
+* https://developers.cloudflare.com/pages/platform/serving-pages/#not-found-behavior
 -->


### PR DESCRIPTION
I had to move an Eleventy site to Cloudflare Pages and was pleasantly surprised when 404.html worked the same as GitHub Pages and Netlify et al.

I updated the website quicktip (11ty/11ty-website#1608).

Updating the base blog, I noticed the inline link to GitLab Pages was missing, so I added that as well.