### PR TITLE
Refactored Drafts plugin

### DIFF
--- a/eleventy.config.drafts.js
+++ b/eleventy.config.drafts.js
@@ -25,8 +25,8 @@ module.exports = eleventyConfig => {
 
 	eleventyConfig.on("eleventy.before", ({ runMode }) => {
 		isServing = runMode === "serve" || runMode === "watch";
-		var text = isServing ? "Including" : "Excluding";
 		if (!isLogged) {
+			let text = isServing ? "Including" : "Excluding";
 			console.log(`[11ty/eleventy-base-blog] ${text} drafts.`);
 			isLogged = true;
 		}


### PR DESCRIPTION
While studying the Drafts plugin for my own work, I realized that the current plugin had a lot more code than needed which affected readability and should have a slight impact on performance. This PR:

* Replaces the environment variable with the `isServing` Boolean (which I think is faster in comparisons).
* Moves the check for the `serve` or `watch` Boolean earlier in the comparison logic so if the build process starts with `serve` or `watch`, the code never even checks `draft` status because draft status doesn't matter at that point. This probably isn't a big deal, but I think it makes it clearer what's happening. With this refactored code, the same number of comparisons happen (I think).
* Renames `logged` to `isLogged` making it clearer that it's a Boolean (for readability) and to align the variable name with `isServing`.
* Moves the `isLogged = true` to the `!isLogged` check block so the value change only happens once instead of every time the watched site rebuilds. In the original, `logged= true` executed with every build which was unnecessary.
* Reduces the code size from 50 lines to 34 (without removing any comments).
