### PR TITLE
Remove the color of '#' from heading-anchors.js

### DIFF
--- a/public/js/heading-anchors.js
+++ b/public/js/heading-anchors.js
@@ -30,7 +30,6 @@ class HeadingAnchors extends HTMLElement {
 	content: "#";
 	content: "#" / "";
 	margin-left: .25em;
-	color: #aaa;
 	opacity: 0;
 }`;
 


### PR DESCRIPTION
Hey! This makes great sense as a web component, but would like to suggest that the color for it isn't hard coded here, so that it's still style-able from the CSS files. Thanks :)