### PR TITLE
fix: permalink = false causes an error with sitemap.xml.njk in v3.0.0

### DIFF
--- a/content/sitemap.xml.njk
+++ b/content/sitemap.xml.njk
@@ -6,10 +6,12 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 {%- for page in collections.all %}
-	{% set absoluteUrl %}{{ page.url | htmlBaseUrl(metadata.url) }}{% endset %}
-	<url>
-		<loc>{{ absoluteUrl }}</loc>
-		<lastmod>{{ page.date | htmlDateString }}</lastmod>
-	</url>
+	{% if page.data.permalink != false %}
+		{% set absoluteUrl %}{{ page.url | htmlBaseUrl(metadata.url) }}{% endset %}
+		<url>
+			<loc>{{ absoluteUrl }}</loc>
+			<lastmod>{{ page.date | htmlDateString }}</lastmod>
+		</url>
+	{% endif %}
 {%- endfor %}
 </urlset>


### PR DESCRIPTION
checks for permalink != false before using htmlBaseUrl filter.

see issue https://github.com/11ty/eleventy/issues/3503 for more details.