### PR TITLE
Auto-append "draft" title text

### DIFF
--- a/content/blog/fifthpost.md
+++ b/content/blog/fifthpost.md
@@ -1,5 +1,5 @@
 ---js
-const title = "This is a fifth post (draft)";
+const title = "This is a fifth post";
 const date = "2023-01-23";
 const draft = true;
 ---

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -10,6 +10,10 @@ import pluginFilters from "./_config/filters.js";
 export default async function(eleventyConfig) {
 	// Drafts, see also _data/eleventyDataSchema.js
 	eleventyConfig.addPreprocessor("drafts", "*", (data, content) => {
+		if (data.draft) {
+      data.title = `${data.title} (draft)`;
+    }
+
 		if(data.draft && process.env.ELEVENTY_RUN_MODE === "build") {
 			return false;
 		}


### PR DESCRIPTION
A small helper I'm adding to my own blog instance, and thought might be useful to others!

To limit manual steps and content editing, we can append `"draft"` to the title of any blog already marked draft in the front-matter. 