### PR TITLE
Exclude Atom feed stylesheet from GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+content/feed/pretty-atom-feed.xsl linguist-vendored


### PR DESCRIPTION
Adds an [override attribute for vendored code](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#vendored-code) (for GitHub's Linguist analyzer), which excludes this file from the language analysis of the repository.

Currently Linguist thinks this repository is 80% XSLT because of how large that one file is.

![CleanShot 2025-05-10 at 18 14 58](https://github.com/user-attachments/assets/ef368a55-ba51-4639-9aa7-a4e2c2bdc41e)